### PR TITLE
Use Closures for registering blocks

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,7 +3,7 @@ description: A PocketMine-MP plugin that implements support for custom blocks, i
 
 main: customiesdevs\customies\Customies
 src-namespace-prefix: customiesdevs\customies
-version: 1.0.7
+version: 1.1.0
 api: 4.0.0
 
 authors:

--- a/src/block/CustomiesBlockFactory.php
+++ b/src/block/CustomiesBlockFactory.php
@@ -78,8 +78,8 @@ final class CustomiesBlockFactory {
 	 * can result in massive issues with almost every block showing as the wrong thing and causing lag to clients.
 	 */
 	public function addWorkerInitHook(): void {
-		$blocks = serialize($this->blockFuncs);
 		$server = Server::getInstance();
+		$blocks = $this->blockFuncs;
 		$server->getAsyncPool()->addWorkerStartHook(static function (int $worker) use ($server, $blocks): void {
 			$server->getAsyncPool()->submitTaskToWorker(new AsyncRegisterBlocksTask($blocks), $worker);
 		});

--- a/src/block/CustomiesBlockFactory.php
+++ b/src/block/CustomiesBlockFactory.php
@@ -161,7 +161,7 @@ final class CustomiesBlockFactory {
 
 		$this->blockPaletteEntries[] = new BlockPaletteEntry($identifier, new CacheableNbt($propertiesTag));
 
-		$this->blockFuncs[$identifier] = $block;
+		$this->blockFuncs[$identifier] = $blockFunc;
 		LegacyBlockIdToStringIdMap::getInstance()->registerMapping($identifier, $block->getId());
 	}
 

--- a/src/block/CustomiesBlockFactory.php
+++ b/src/block/CustomiesBlockFactory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace customiesdevs\customies\block;
 
+use Closure;
 use customiesdevs\customies\item\CreativeInventoryInfo;
 use customiesdevs\customies\item\CustomiesItemFactory;
 use customiesdevs\customies\task\AsyncRegisterBlocksTask;
@@ -10,9 +11,7 @@ use customiesdevs\customies\world\LegacyBlockIdToStringIdMap;
 use InvalidArgumentException;
 use OutOfRangeException;
 use pocketmine\block\Block;
-use pocketmine\block\BlockBreakInfo;
 use pocketmine\block\BlockFactory;
-use pocketmine\block\BlockIdentifier;
 use pocketmine\inventory\CreativeInventory;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\network\mcpe\convert\GlobalItemTypeDictionary;
@@ -25,7 +24,6 @@ use pocketmine\network\mcpe\protocol\types\BlockPaletteEntry;
 use pocketmine\network\mcpe\protocol\types\CacheableNbt;
 use pocketmine\Server;
 use pocketmine\utils\SingletonTrait;
-use pocketmine\utils\Utils;
 use ReflectionClass;
 use RuntimeException;
 use SplFixedArray;
@@ -40,10 +38,10 @@ final class CustomiesBlockFactory {
 	private const NEW_BLOCK_FACTORY_SIZE = 2048 << Block::INTERNAL_METADATA_BITS;
 
 	/**
-	 * @var Block[]
-	 * @phpstan-var array<string, Block>
+	 * @var Closure[]
+	 * @phpstan-var array<string, Closure(int): Block>
 	 */
-	private array $customBlocks = [];
+	private array $blockFuncs = [];
 	/** @var BlockPaletteEntry[] */
 	private array $blockPaletteEntries = [];
 	/** @var R12ToCurrentBlockMapEntry[] */
@@ -68,10 +66,10 @@ final class CustomiesBlockFactory {
 			$array->setSize(self::NEW_BLOCK_FACTORY_SIZE);
 			$property->setValue($instance, $array);
 		}
-        $instance->light = SplFixedArray::fromArray(array_merge($instance->light->toArray(), array_fill(count($instance->light), self::NEW_BLOCK_FACTORY_SIZE, 0)));
-        $instance->lightFilter = SplFixedArray::fromArray(array_merge($instance->lightFilter->toArray(), array_fill(count($instance->lightFilter), self::NEW_BLOCK_FACTORY_SIZE, 1)));
-        $instance->blocksDirectSkyLight = SplFixedArray::fromArray(array_merge($instance->blocksDirectSkyLight->toArray(), array_fill(count($instance->blocksDirectSkyLight), self::NEW_BLOCK_FACTORY_SIZE, false)));
-        $instance->blastResistance = SplFixedArray::fromArray(array_merge($instance->blastResistance->toArray(), array_fill(count($instance->blastResistance), self::NEW_BLOCK_FACTORY_SIZE, 0.0)));
+		$instance->light = SplFixedArray::fromArray(array_merge($instance->light->toArray(), array_fill(count($instance->light), self::NEW_BLOCK_FACTORY_SIZE, 0)));
+		$instance->lightFilter = SplFixedArray::fromArray(array_merge($instance->lightFilter->toArray(), array_fill(count($instance->lightFilter), self::NEW_BLOCK_FACTORY_SIZE, 1)));
+		$instance->blocksDirectSkyLight = SplFixedArray::fromArray(array_merge($instance->blocksDirectSkyLight->toArray(), array_fill(count($instance->blocksDirectSkyLight), self::NEW_BLOCK_FACTORY_SIZE, false)));
+		$instance->blastResistance = SplFixedArray::fromArray(array_merge($instance->blastResistance->toArray(), array_fill(count($instance->blastResistance), self::NEW_BLOCK_FACTORY_SIZE, 0.0)));
 	}
 
 	/**
@@ -80,7 +78,7 @@ final class CustomiesBlockFactory {
 	 * can result in massive issues with almost every block showing as the wrong thing and causing lag to clients.
 	 */
 	public function addWorkerInitHook(): void {
-		$blocks = serialize($this->customBlocks);
+		$blocks = serialize($this->blockFuncs);
 		$server = Server::getInstance();
 		$server->getAsyncPool()->addWorkerStartHook(static function (int $worker) use ($server, $blocks): void {
 			$server->getAsyncPool()->submitTaskToWorker(new AsyncRegisterBlocksTask($blocks), $worker);
@@ -109,15 +107,14 @@ final class CustomiesBlockFactory {
 
 	/**
 	 * Register a block to the BlockFactory and all the required mappings.
-	 * @phpstan-param class-string $className
+	 * @phpstan-param (Closure(int): Block) $blockFunc
 	 */
-	public function registerBlock(string $className, string $identifier, string $name, BlockBreakInfo $breakInfo, ?Model $model = null, ?CreativeInventoryInfo $creativeInfo = null): void {
-		if($className !== Block::class) {
-			Utils::testValidInstance($className, Block::class);
+	public function registerBlock(Closure $blockFunc, string $identifier, ?Model $model = null, ?CreativeInventoryInfo $creativeInfo = null): void {
+		$id = $this->getNextAvailableId();
+		$block = $blockFunc($id);
+		if(!$block instanceof Block) {
+			throw new InvalidArgumentException("Class returned from closure is not a Block");
 		}
-
-		/** @var Block $block */
-		$block = new $className(new BlockIdentifier($this->getNextAvailableId(), 0), $name, $breakInfo);
 
 		if(BlockFactory::getInstance()->isRegistered($block->getId())) {
 			throw new InvalidArgumentException("Block with ID " . $block->getId() . " is already registered");
@@ -131,20 +128,20 @@ final class CustomiesBlockFactory {
 		BlockPalette::getInstance()->insertState($blockState);
 
 		$propertiesTag = CompoundTag::create();
-        $components = CompoundTag::create()
-            ->setTag("minecraft:light_emission", CompoundTag::create()
-                ->setByte("emission", $block->getLightLevel()))
-            ->setTag("minecraft:block_light_filter", CompoundTag::create()
-                ->setByte("lightLevel", $block->getLightFilter()))
-            ->setTag("minecraft:destructible_by_mining", CompoundTag::create()
-                ->setFloat("value", $block->getBreakInfo()->getHardness()))//Says seconds_to_destroy in docs
-            ->setTag("minecraft:destructible_by_explosion", CompoundTag::create()
-                ->setFloat("value", $block->getBreakInfo()->getBlastResistance()))//Uses explosion_resistance in docs
-            ->setTag("minecraft:friction", CompoundTag::create()
-                ->setFloat("value", $block->getFrictionFactor()))
-            ->setTag("minecraft:flammable", CompoundTag::create()
-                ->setInt("catch_chance_modifier", $block->getFlameEncouragement())
-                ->setInt("destroy_chance_modifier", $block->getFlammability()));
+		$components = CompoundTag::create()
+			->setTag("minecraft:light_emission", CompoundTag::create()
+				->setByte("emission", $block->getLightLevel()))
+			->setTag("minecraft:block_light_filter", CompoundTag::create()
+				->setByte("lightLevel", $block->getLightFilter()))
+			->setTag("minecraft:destructible_by_mining", CompoundTag::create()
+				->setFloat("value", $block->getBreakInfo()->getHardness()))//Says seconds_to_destroy in docs
+			->setTag("minecraft:destructible_by_explosion", CompoundTag::create()
+				->setFloat("value", $block->getBreakInfo()->getBlastResistance()))//Uses explosion_resistance in docs
+			->setTag("minecraft:friction", CompoundTag::create()
+				->setFloat("value", $block->getFrictionFactor()))
+			->setTag("minecraft:flammable", CompoundTag::create()
+				->setInt("catch_chance_modifier", $block->getFlameEncouragement())
+				->setInt("destroy_chance_modifier", $block->getFlammability()));
 
 		if($model !== null) {
 			foreach($model->toNBT() as $tagName => $tag){
@@ -164,7 +161,7 @@ final class CustomiesBlockFactory {
 
 		$this->blockPaletteEntries[] = new BlockPaletteEntry($identifier, new CacheableNbt($propertiesTag));
 
-		$this->customBlocks[$identifier] = $block;
+		$this->blockFuncs[$identifier] = $block;
 		LegacyBlockIdToStringIdMap::getInstance()->registerMapping($identifier, $block->getId());
 	}
 
@@ -172,7 +169,7 @@ final class CustomiesBlockFactory {
 	 * Returns the next available custom block id, an exception will be thrown if the block factory is full.
 	 */
 	private function getNextAvailableId(): int {
-		$id = 1000 + count($this->customBlocks);
+		$id = 1000 + count($this->blockFuncs);
 		if($id > (self::NEW_BLOCK_FACTORY_SIZE / 16)) {
 			throw new OutOfRangeException("All custom block ids are used up");
 		}

--- a/src/block/Model.php
+++ b/src/block/Model.php
@@ -42,7 +42,19 @@ final class Model {
 				->setTag("materials", $materials),
 			"minecraft:geometry" => CompoundTag::create()
 				->setString("value", $this->geometry),
-			"minecraft:pick_collision" => CompoundTag::create()
+			"minecraft:collision_box" => CompoundTag::create()
+				->setByte("enabled", 1)
+				->setTag("origin", new ListTag([
+					new FloatTag($this->origin->getX()),
+					new FloatTag($this->origin->getY()),
+					new FloatTag($this->origin->getZ())
+				]))
+				->setTag("size", new ListTag([
+					new FloatTag($this->size->getX()),
+					new FloatTag($this->size->getY()),
+					new FloatTag($this->size->getZ())
+				])),
+			"minecraft:selection_box" => CompoundTag::create()
 				->setByte("enabled", 1)
 				->setTag("origin", new ListTag([
 					new FloatTag($this->origin->getX()),

--- a/src/entity/CustomiesEntityFactory.php
+++ b/src/entity/CustomiesEntityFactory.php
@@ -26,8 +26,8 @@ class CustomiesEntityFactory {
 	 */
 	public function registerEntity(string $className, string $identifier, ?Closure $creationFunc = null): void {
 		EntityFactory::getInstance()->register($className, $creationFunc ?? static function (World $world, CompoundTag $nbt) use ($className): Entity {
-				return new $className(EntityDataHelper::parseLocation($nbt, $world), $nbt);
-			}, [$identifier]);
+			return new $className(EntityDataHelper::parseLocation($nbt, $world), $nbt);
+		}, [$identifier]);
 		$this->updateStaticPacketCache($identifier);
 	}
 

--- a/src/task/AsyncRegisterBlocksTask.php
+++ b/src/task/AsyncRegisterBlocksTask.php
@@ -3,19 +3,29 @@ declare(strict_types=1);
 
 namespace customiesdevs\customies\task;
 
+use Closure;
 use customiesdevs\customies\block\CustomiesBlockFactory;
 use pocketmine\block\Block;
 use pocketmine\scheduler\AsyncTask;
+use Threaded;
 
 final class AsyncRegisterBlocksTask extends AsyncTask {
 
-	public function __construct(private string $blocks) {
+	private Threaded $blockFuncs;
+
+	/**
+	 * @param Closure[] $blockFuncs
+	 * @phpstan-param array<string, Closure(int): Block> $blockFuncs
+	 */
+	public function __construct(array $blockFuncs) {
+		$this->blockFuncs = new Threaded();
+		foreach($blockFuncs as $identifier => $blockFunc) {
+			$this->blockFuncs[$identifier] = $blockFunc;
+		}
 	}
 
 	public function onRun(): void {
-		/** @phpstan-var array<string, Closure(int): Block> $blocks */
-		$blocks = unserialize($this->blocks);
-		foreach($blocks as $identifier => $blockFunc){
+		foreach($this->blockFuncs as $identifier => $blockFunc){
 			// We do not care about the model or creative inventory data in other threads since it is unused outside of
 			// the main thread.
 			CustomiesBlockFactory::getInstance()->registerBlock($blockFunc, $identifier);

--- a/src/task/AsyncRegisterBlocksTask.php
+++ b/src/task/AsyncRegisterBlocksTask.php
@@ -13,12 +13,12 @@ final class AsyncRegisterBlocksTask extends AsyncTask {
 	}
 
 	public function onRun(): void {
-		/** @phpstan-var array<string, Block> $blocks */
+		/** @phpstan-var array<string, Closure(int): Block> $blocks */
 		$blocks = unserialize($this->blocks);
-		foreach($blocks as $identifier => $block){
-			/** @phpstan-var class-string $className */
-			$className = get_class($block);
-			CustomiesBlockFactory::getInstance()->registerBlock($className, $identifier, $block->getName(), $block->getBreakInfo());
+		foreach($blocks as $identifier => $blockFunc){
+			// We do not care about the model or creative inventory data in other threads since it is unused outside of
+			// the main thread.
+			CustomiesBlockFactory::getInstance()->registerBlock($blockFunc, $identifier);
 		}
 		CustomiesBlockFactory::getInstance()->registerCustomRuntimeMappings();
 	}

--- a/src/task/AsyncRegisterBlocksTask.php
+++ b/src/task/AsyncRegisterBlocksTask.php
@@ -19,7 +19,7 @@ final class AsyncRegisterBlocksTask extends AsyncTask {
 	 */
 	public function __construct(array $blockFuncs) {
 		$this->blockFuncs = new Threaded();
-		foreach($blockFuncs as $identifier => $blockFunc) {
+		foreach($blockFuncs as $identifier => $blockFunc){
 			$this->blockFuncs[$identifier] = $blockFunc;
 		}
 	}


### PR DESCRIPTION
This pull request aims to solve two big problems with the `CustomiesBlockFactory->registerBlock()` API:
1. The current method is very limiting and does not work for every type of block due to different constructor signatures. For example slabs require a `BlockIdentifierFlattened` whereas we only accept a `BlockIdentifier`, meaning the user needs to create a new class that inherits the same behaviour to use within Customies.
2. The way we currently register blocks on all threads is by serializing the Block objects and using the same registering method. This causes issues when blocks inherit properties that are not serialiable, crashing the server as a result. Using slabs as an example again, their `SlabType` is an enum which implements the `NotSerializable` trait.

The solution to both of these problems is instead of accepting a class name along with other information such as `BlockBreakInfo`, we instead accept a single Closure which returns an instance of the Block. This allows for blocks to be constructed however they are needed, and also removes the requirement for serializing the Block objects to register them on other threads.