### PR TITLE
Allow compound components

### DIFF
--- a/src/item/ItemComponentsTrait.php
+++ b/src/item/ItemComponentsTrait.php
@@ -11,6 +11,8 @@ use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\nbt\tag\Tag;
 use RuntimeException;
+use function array_keys;
+use function is_int;
 
 trait ItemComponentsTrait {
 
@@ -34,7 +36,7 @@ trait ItemComponentsTrait {
 	 */
 	private function getTagType($type): ?Tag {
 		return match (true) {
-			is_array($type) => new ListTag($type),
+			is_array($type) => $this->getArrayTag($type),
 			is_bool($type) => new ByteTag($type ? 1 : 0),
 			is_float($type) => new FloatTag($type),
 			is_int($type) => new IntTag($type),
@@ -42,6 +44,20 @@ trait ItemComponentsTrait {
 			$type instanceof CompoundTag => $type,
 			default => null,
 		};
+	}
+
+	/**
+	 * Creates a Tag that is either a ListTag or CompoundTag based on the data types of the keys in the provided array.
+	 */
+	private function getArrayTag(array $array): Tag {
+		if(array_keys($array) === range(0, count($array) - 1)) {
+			return new ListTag($array);
+		}
+		$tag = CompoundTag::create();
+		foreach($array as $key => $value){
+			$tag->setTag($key, $this->getTagType($value));
+		}
+		return $tag;
 	}
 
 	/**


### PR DESCRIPTION
Concept is based on https://github.com/CustomiesDevs/Customies/pull/29, but the author of this PR has been inactive and there was a few issues with their implementation. This implementation allows for `ListTag`s and `CompoundTag`s to be used for custom item components/properties.