### PR TITLE
Block permutations

### DIFF
--- a/src/Customies.php
+++ b/src/Customies.php
@@ -24,7 +24,7 @@ final class Customies extends PluginBase {
 		$this->getServer()->getPluginManager()->registerEvents(new CustomiesListener(), $this);
 
 		$cachePath = $this->getDataFolder() . "idcache";
-		$this->getScheduler()->scheduleDelayedTask(new ClosureTask(static function () use($cachePath): void {
+		$this->getScheduler()->scheduleDelayedTask(new ClosureTask(static function () use ($cachePath): void {
 			// This task is scheduled with a 0-tick delay so it runs as soon as the server has started. Plugins should
 			// register their custom blocks and entities in onEnable() before this is executed.
 			Cache::getInstance()->save();

--- a/src/block/BlockPalette.php
+++ b/src/block/BlockPalette.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace customiesdevs\customies\block;
 
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\network\mcpe\convert\R12ToCurrentBlockMapEntry;
 use pocketmine\network\mcpe\convert\RuntimeBlockMapping;
 use pocketmine\utils\SingletonTrait;
 use ReflectionClass;
@@ -15,7 +16,7 @@ final class BlockPalette {
 
 	/** @var CompoundTag[] */
 	private array $states;
-	/** @var CompoundTag[] */
+	/** @var R12ToCurrentBlockMapEntry[] */
 	private array $customStates = [];
 
 	private RuntimeBlockMapping $runtimeBlockMapping;
@@ -37,7 +38,7 @@ final class BlockPalette {
 	}
 
 	/**
-	 * @return CompoundTag[]
+	 * @return R12ToCurrentBlockMapEntry[]
 	 */
 	public function getCustomStates(): array {
 		return $this->customStates;
@@ -46,29 +47,36 @@ final class BlockPalette {
 	/**
 	 * Inserts the provided state in to the correct position of the palette.
 	 */
-	public function insertState(CompoundTag $state): void {
-		if($state->getString("name" . "") === "") {
+	public function insertState(CompoundTag $state, int $meta = 0): void {
+		if($state->getString("name") === "") {
 			throw new RuntimeException("Block state must contain a StringTag called 'name'");
 		}
 		if($state->getCompoundTag("states") === null) {
 			throw new RuntimeException("Block state must contain a CompoundTag called 'states'");
 		}
 		$this->sortWith($state);
-		$this->customStates[] = $state;
+		$this->customStates[] = new R12ToCurrentBlockMapEntry($state->getString("name"), $meta, $state);
 	}
 
 	/**
 	 * Sorts the palette's block states in the correct order, also adding the provided state to the array.
 	 */
-	private function sortWith(CompoundTag $state): void {
-		$states = [$state->getString("name") => [$state]];
+	private function sortWith(CompoundTag $newState): void {
+		// To sort the block palette we first have to split the palette up in to groups of states. We only want to sort
+		// using the name of the block, and keeping the order of the existing states.
+		$states = [];
 		foreach($this->states as $state){
 			$states[$state->getString("name")][] = $state;
 		}
+		// Append the new state we are sorting with at the end to preserve existing order.
+		$states[$newState->getString("name")][] = $newState;
+
 		$names = array_keys($states);
+		// As of 1.18.30, blocks are sorted using a fnv164 hash of their names.
 		usort($names, static fn(string $a, string $b) => strcmp(hash("fnv164", $a), hash("fnv164", $b)));
 		$sortedStates = [];
 		foreach($names as $name){
+			// With the sorted list of names, we can now go back and add all the states for each block in the correct order.
 			foreach($states[$name] as $state){
 				$sortedStates[] = $state;
 			}

--- a/src/block/Material.php
+++ b/src/block/Material.php
@@ -8,9 +8,13 @@ use pocketmine\nbt\tag\CompoundTag;
 final class Material {
 
 	public const TARGET_ALL = "*";
+	public const TARGET_SIDES = "sides";
 	public const TARGET_UP = "up";
 	public const TARGET_DOWN = "down";
-	public const TARGET_SIDES = "sides";
+	public const TARGET_NORTH = "north";
+	public const TARGET_EAST = "east";
+	public const TARGET_SOUTH = "south";
+	public const TARGET_WEST = "west";
 
 	public const RENDER_METHOD_ALPHA_TEST = "alpha_test";
 	public const RENDER_METHOD_BLEND = "blend";

--- a/src/block/permutations/BlockProperty.php
+++ b/src/block/permutations/BlockProperty.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace customiesdevs\customies\block\permutations;
+
+use customiesdevs\customies\util\NBT;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\ListTag;
+use function array_map;
+
+final class BlockProperty {
+
+	private string $name;
+	private array $values;
+
+	public function __construct(string $name, array $values) {
+		$this->name = $name;
+		$this->values = $values;
+	}
+
+	/**
+	 * Returns the name of the block property provided in the constructor.
+	 */
+	public function getName(): string {
+		return $this->name;
+	}
+
+	/**
+	 * Returns the array of possible values of the block property provided in the constructor.
+	 */
+	public function getValues(): array {
+		return $this->values;
+	}
+
+	/**
+	 * Returns the block property in the correct NBT format supported by the client.
+	 */
+	public function toNBT(): CompoundTag {
+		$values = array_map(static fn($value) => NBT::getTagType($value), $this->values);
+		return CompoundTag::create()
+			->setString("name", $this->name)
+			->setTag("enum", new ListTag($values));
+	}
+}

--- a/src/block/permutations/Permutable.php
+++ b/src/block/permutations/Permutable.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace customiesdevs\customies\block\permutations;
+
+interface Permutable {
+
+	/**
+	 * Returns an array of the different block properties the block has. When the block is registered, it is registered
+	 * with all the possible combinations of all the block properties returned.
+	 * @return BlockProperty[]
+	 */
+	public function getBlockProperties(): array;
+
+	/**
+	 * Returns an array of the permutations the block has. They contain molang queries that can use the block properties
+	 * to control the components based on different states server-side.
+	 * @return Permutation[]
+	 */
+	public function getPermutations(): array;
+
+	/**
+	 * Returns an array of the current block property values in the same order as those in getBlockProperties(). It is
+	 * used to convert the current properties in to a meta value that can stored on disk in the world.
+	 */
+	public function getCurrentBlockProperties(): array;
+}

--- a/src/block/permutations/Permutable.php
+++ b/src/block/permutations/Permutable.php
@@ -21,7 +21,7 @@ interface Permutable {
 
 	/**
 	 * Returns an array of the current block property values in the same order as those in getBlockProperties(). It is
-	 * used to convert the current properties in to a meta value that can stored on disk in the world.
+	 * used to convert the current properties in to a meta value that can be stored on disk in the world.
 	 */
 	public function getCurrentBlockProperties(): array;
 }

--- a/src/block/permutations/Permutation.php
+++ b/src/block/permutations/Permutation.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace customiesdevs\customies\block\permutations;
+
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\Tag;
+
+final class Permutation {
+
+	private string $condition;
+	private CompoundTag $components;
+
+	public function __construct(string $condition) {
+		$this->condition = $condition;
+		$this->components = CompoundTag::create();
+	}
+
+	/**
+	 * Returns the permutation with the provided component added to the current list of components.
+	 */
+	public function withComponent(string $component, Tag $tag) : self {
+		$this->components->setTag($component, $tag);
+		return $this;
+	}
+
+	/**
+	 * Returns the permutation in the correct NBT format supported by the client.
+	 */
+	public function toNBT(): CompoundTag {
+		return CompoundTag::create()
+			->setString("condition", $this->condition)
+			->setTag("components", $this->components);
+	}
+}

--- a/src/block/permutations/Permutations.php
+++ b/src/block/permutations/Permutations.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace customiesdevs\customies\block\permutations;
+
+use pocketmine\block\utils\InvalidBlockStateException;
+use function array_map;
+use function count;
+use function current;
+use function next;
+use function reset;
+
+class Permutations {
+
+	/**
+	 * Attempts to return an array of block properties from the provided meta value based on the possible permutations
+	 * of the block. an exception is thrown if the meta value does not match any combinations of all the block
+	 * properties.
+	 */
+	public static function fromMeta(Permutable $block, int $meta): array {
+		$possibleValues = array_map(static fn(BlockProperty $blockProperty) => $blockProperty->getValues(), $block->getBlockProperties());
+		$properties = self::getCartesianProduct($possibleValues)[$meta] ?? null;
+		if($properties === null) {
+			throw new InvalidBlockStateException("Unable to calculate permutations from block meta: " . $meta);
+		}
+		return $properties;
+	}
+
+	/**
+	 * Attempts to convert the block in to a meta value based on the possible permutations of the block. An exception is
+	 * thrown if the state of the block is not a possible combination of all the block properties.
+	 */
+	public static function toMeta(Permutable $block): int {
+		$possibleValues = array_map(static fn(BlockProperty $blockProperty) => $blockProperty->getValues(), $block->getBlockProperties());
+		foreach(self::getCartesianProduct($possibleValues) as $meta => $permutations){
+			if($permutations === $block->getCurrentBlockProperties()) {
+				return $meta;
+			}
+		}
+		throw new InvalidBlockStateException("Unable to calculate block meta from current permutations");
+	}
+
+	/**
+	 * Returns the number of bits required to represent all the possible permutations of the block.
+	 */
+	public static function getStateBitmask(Permutable $block): int {
+		$possibleValues = array_map(static fn(BlockProperty $blockProperty) => $blockProperty->getValues(), $block->getBlockProperties());
+		return count(self::getCartesianProduct($possibleValues)) - 1;
+	}
+
+	/**
+	 * Returns an 2-dimensional array containing all possible combinations of the provided arrays using the cartesian
+	 * product (https://en.wikipedia.org/wiki/Cartesian_product).
+	 */
+	public static function getCartesianProduct(array $arrays): array {
+		$result = [];
+		$count = count($arrays) - 1;
+		$combinations = array_product(array_map(static fn(array $array) => count($array), $arrays));
+		for($i = 0; $i < $combinations; $i++){
+			$result[] = array_map(static fn(array $array) => current($array), $arrays);
+			for($j = $count; $j >= 0; $j--){
+				if(next($arrays[$j])) {
+					break;
+				}
+				reset($arrays[$j]);
+			}
+		}
+		return $result;
+	}
+}

--- a/src/block/permutations/Permutations.php
+++ b/src/block/permutations/Permutations.php
@@ -14,7 +14,7 @@ class Permutations {
 
 	/**
 	 * Attempts to return an array of block properties from the provided meta value based on the possible permutations
-	 * of the block. an exception is thrown if the meta value does not match any combinations of all the block
+	 * of the block. An exception is thrown if the meta value does not match any combinations of all the block
 	 * properties.
 	 */
 	public static function fromMeta(Permutable $block, int $meta): array {

--- a/src/block/permutations/RotatableTrait.php
+++ b/src/block/permutations/RotatableTrait.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace customiesdevs\customies\block\permutations;
+
+use pocketmine\block\Block;
+use pocketmine\block\utils\HorizontalFacingTrait;
+use pocketmine\item\Item;
+use pocketmine\math\Facing;
+use pocketmine\math\Vector3;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\player\Player;
+use pocketmine\world\BlockTransaction;
+
+trait RotatableTrait {
+	use HorizontalFacingTrait;
+
+	/**
+	 * @return BlockProperty[]
+	 */
+	public function getBlockProperties(): array {
+		return [
+			new BlockProperty("customies:rotation", [2, 3, 4, 5]),
+		];
+	}
+
+	/**
+	 * @return Permutation[]
+	 */
+	public function getPermutations(): array {
+		return [
+			(new Permutation("q.block_property('customies:rotation') == 2"))
+				->withComponent("minecraft:rotation", CompoundTag::create()
+					->setFloat("x", 0)
+					->setFloat("y", 0)
+					->setFloat("z", 0)),
+			(new Permutation("q.block_property('customies:rotation') == 3"))
+				->withComponent("minecraft:rotation", CompoundTag::create()
+					->setFloat("x", 0)
+					->setFloat("y", 180)
+					->setFloat("z", 0)),
+			(new Permutation("q.block_property('customies:rotation') == 4"))
+				->withComponent("minecraft:rotation", CompoundTag::create()
+					->setFloat("x", 0)
+					->setFloat("y", 45)
+					->setFloat("z", 0)),
+			(new Permutation("q.block_property('customies:rotation') == 5"))
+				->withComponent("minecraft:rotation", CompoundTag::create()
+					->setFloat("x", 0)
+					->setFloat("y", 270)
+					->setFloat("z", 0)),
+		];
+	}
+
+	public function getCurrentBlockProperties(): array {
+		return [$this->facing];
+	}
+
+	protected function writeStateToMeta(): int {
+		return Permutations::toMeta($this);
+	}
+
+	public function readStateFromData(int $id, int $stateMeta): void {
+		$blockProperties = Permutations::fromMeta($this, $stateMeta);
+		$this->facing = $blockProperties[0] ?? Facing::NORTH;
+	}
+
+	public function getStateBitmask(): int {
+		return Permutations::getStateBitmask($this);
+	}
+
+	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null): bool {
+		if($player !== null) {
+			$this->facing = $player->getHorizontalFacing();
+		}
+		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+}

--- a/src/item/CustomiesItemFactory.php
+++ b/src/item/CustomiesItemFactory.php
@@ -5,6 +5,7 @@ namespace customiesdevs\customies\item;
 
 use customiesdevs\customies\util\Cache;
 use InvalidArgumentException;
+use pocketmine\block\Block;
 use pocketmine\inventory\CreativeInventory;
 use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
@@ -112,8 +113,8 @@ final class CustomiesItemFactory {
 	 * Registers the required mappings for the block to become an item that can be placed etc. It is assigned an ID that
 	 * correlates to its block ID.
 	 */
-	public function registerBlockItem(string $identifier, int $blockId): void {
-		$itemId = 255 - $blockId;
+	public function registerBlockItem(string $identifier, Block $block): void {
+		$itemId = $block->getIdInfo()->getItemId();
 		$this->registerCustomItemMapping($itemId);
 		$this->itemTableEntries[] = new ItemTypeEntry($identifier, $itemId, false);
 	}

--- a/src/item/ItemComponentsTrait.php
+++ b/src/item/ItemComponentsTrait.php
@@ -3,16 +3,11 @@ declare(strict_types=1);
 
 namespace customiesdevs\customies\item;
 
-use pocketmine\nbt\tag\ByteTag;
+use customiesdevs\customies\util\NBT;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
-use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ListTag;
-use pocketmine\nbt\tag\StringTag;
-use pocketmine\nbt\tag\Tag;
 use RuntimeException;
-use function array_keys;
-use function is_int;
 
 trait ItemComponentsTrait {
 
@@ -24,40 +19,11 @@ trait ItemComponentsTrait {
 	 */
 	public function addProperty(string $key, $value): void {
 		$propertiesTag = $this->componentTag->getCompoundTag("components")->getCompoundTag("item_properties");
-		$tag = $this->getTagType($value);
+		$tag = NBT::getTagType($value);
 		if($tag === null) {
 			throw new RuntimeException("Failed to get tag type for property with key " . $key);
 		}
 		$propertiesTag->setTag($key, $tag);
-	}
-
-	/**
-	 * Attempts to return the correct Tag for the provided type.
-	 */
-	private function getTagType($type): ?Tag {
-		return match (true) {
-			is_array($type) => $this->getArrayTag($type),
-			is_bool($type) => new ByteTag($type ? 1 : 0),
-			is_float($type) => new FloatTag($type),
-			is_int($type) => new IntTag($type),
-			is_string($type) => new StringTag($type),
-			$type instanceof CompoundTag => $type,
-			default => null,
-		};
-	}
-
-	/**
-	 * Creates a Tag that is either a ListTag or CompoundTag based on the data types of the keys in the provided array.
-	 */
-	private function getArrayTag(array $array): Tag {
-		if(array_keys($array) === range(0, count($array) - 1)) {
-			return new ListTag($array);
-		}
-		$tag = CompoundTag::create();
-		foreach($array as $key => $value){
-			$tag->setTag($key, $this->getTagType($value));
-		}
-		return $tag;
 	}
 
 	/**
@@ -66,7 +32,7 @@ trait ItemComponentsTrait {
 	 */
 	public function addComponent(string $key, $value): void {
 		$componentsTag = $this->componentTag->getCompoundTag("components");
-		$tag = $this->getTagType($value);
+		$tag = NBT::getTagType($value);
 		if($tag === null) {
 			throw new RuntimeException("Failed to get tag type for component with key " . $key);
 		}

--- a/src/util/NBT.php
+++ b/src/util/NBT.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace customiesdevs\customies\util;
+
+use pocketmine\nbt\tag\ByteTag;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\FloatTag;
+use pocketmine\nbt\tag\IntTag;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\StringTag;
+use pocketmine\nbt\tag\Tag;
+use function array_keys;
+use function count;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+use function range;
+
+class NBT {
+
+	/**
+	 * Attempts to return the correct Tag for the provided type.
+	 */
+	public static function getTagType($type): ?Tag {
+		return match (true) {
+			is_array($type) => self::getArrayTag($type),
+			is_bool($type) => new ByteTag($type ? 1 : 0),
+			is_float($type) => new FloatTag($type),
+			is_int($type) => new IntTag($type),
+			is_string($type) => new StringTag($type),
+			$type instanceof CompoundTag => $type,
+			default => null,
+		};
+	}
+
+	/**
+	 * Creates a Tag that is either a ListTag or CompoundTag based on the data types of the keys in the provided array.
+	 */
+	private static function getArrayTag(array $array): Tag {
+		if(array_keys($array) === range(0, count($array) - 1)) {
+			return new ListTag($array);
+		}
+		$tag = CompoundTag::create();
+		foreach($array as $key => $value){
+			$tag->setTag($key, self::getTagType($value));
+		}
+		return $tag;
+	}
+}


### PR DESCRIPTION
Block permutations allow for users to create blocks that can have different components based on a server-side state, all in one block. For example, a crop with 7 stages of growth would currently require you to register 7 individual blocks. With this PR, all that can be achieved in just a single block. A built-in RotatableTrait has also been added for users to easily add horizontal rotation to any of their blocks.