### PR TITLE
Update customizes to PMMP 1.16.0

### DIFF
--- a/src/block/CustomiesBlockFactory.php
+++ b/src/block/CustomiesBlockFactory.php
@@ -68,10 +68,10 @@ final class CustomiesBlockFactory {
 			$array->setSize(self::NEW_BLOCK_FACTORY_SIZE);
 			$property->setValue($instance, $array);
 		}
-		$instance->light = SplFixedArray::fromArray(array_fill(0, self::NEW_BLOCK_FACTORY_SIZE, 0));
-		$instance->lightFilter = SplFixedArray::fromArray(array_fill(0, self::NEW_BLOCK_FACTORY_SIZE, 1));
-		$instance->blocksDirectSkyLight = SplFixedArray::fromArray(array_fill(0, self::NEW_BLOCK_FACTORY_SIZE, false));
-		$instance->blastResistance = SplFixedArray::fromArray(array_fill(0, self::NEW_BLOCK_FACTORY_SIZE, 0.0));
+        $instance->light = SplFixedArray::fromArray(array_merge($instance->light->toArray(), array_fill(count($instance->light), self::NEW_BLOCK_FACTORY_SIZE, 0)));
+        $instance->lightFilter = SplFixedArray::fromArray(array_merge($instance->lightFilter->toArray(), array_fill(count($instance->lightFilter), self::NEW_BLOCK_FACTORY_SIZE, 1)));
+        $instance->blocksDirectSkyLight = SplFixedArray::fromArray(array_merge($instance->blocksDirectSkyLight->toArray(), array_fill(count($instance->blocksDirectSkyLight), self::NEW_BLOCK_FACTORY_SIZE, false)));
+        $instance->blastResistance = SplFixedArray::fromArray(array_merge($instance->blastResistance->toArray(), array_fill(count($instance->blastResistance), self::NEW_BLOCK_FACTORY_SIZE, 0.0)));
 	}
 
 	/**
@@ -131,20 +131,20 @@ final class CustomiesBlockFactory {
 		BlockPalette::getInstance()->insertState($blockState);
 
 		$propertiesTag = CompoundTag::create();
-		$components = CompoundTag::create()
-			->setTag("minecraft:block_light_emission", CompoundTag::create()
-				->setFloat("value", (float)$block->getLightLevel() / 15))
-			->setTag("minecraft:block_light_filter", CompoundTag::create()
-				->setInt("value", $block->getLightFilter()))
-			->setTag("minecraft:destroy_time", CompoundTag::create()
-				->setFloat("value", $block->getBreakInfo()->getHardness()))
-			->setTag("minecraft:explosion_resistance", CompoundTag::create()
-				->setFloat("value", $block->getBreakInfo()->getBlastResistance()))
-			->setTag("minecraft:friction", CompoundTag::create()
-				->setFloat("value", $block->getFrictionFactor()))
-			->setTag("minecraft:flammable", CompoundTag::create()
-				->setFloat("flame_odds", $block->getFlameEncouragement())
-				->setFloat("burn_odds", $block->getFlammability()));
+        $components = CompoundTag::create()
+            ->setTag("minecraft:light_emission", CompoundTag::create()
+                ->setInt("value", $block->getLightLevel()))
+            ->setTag("minecraft:block_light_filter", CompoundTag::create()
+                ->setInt("value", $block->getLightFilter()))
+            ->setTag("minecraft:destructible_by_mining", CompoundTag::create()
+                ->setFloat("value", $block->getBreakInfo()->getHardness()))
+            ->setTag("minecraft:destructible_by_explosion", CompoundTag::create()
+                ->setFloat("value", $block->getBreakInfo()->getBlastResistance()))
+            ->setTag("minecraft:friction", CompoundTag::create()
+                ->setFloat("value", $block->getFrictionFactor()))
+            ->setTag("minecraft:flammable", CompoundTag::create()
+                ->setInt("catch_chance_modifier", $block->getFlameEncouragement())//Did MC revert this change or?
+                ->setInt("destroy_chance_modifier", $block->getFlammability()));
 
 		if($model !== null) {
 			foreach($model->toNBT() as $tagName => $tag){

--- a/src/block/CustomiesBlockFactory.php
+++ b/src/block/CustomiesBlockFactory.php
@@ -133,17 +133,17 @@ final class CustomiesBlockFactory {
 		$propertiesTag = CompoundTag::create();
         $components = CompoundTag::create()
             ->setTag("minecraft:light_emission", CompoundTag::create()
-                ->setInt("value", $block->getLightLevel()))
+                ->setByte("emission", $block->getLightLevel()))
             ->setTag("minecraft:block_light_filter", CompoundTag::create()
-                ->setInt("value", $block->getLightFilter()))
+                ->setByte("lightLevel", $block->getLightFilter()))
             ->setTag("minecraft:destructible_by_mining", CompoundTag::create()
-                ->setFloat("value", $block->getBreakInfo()->getHardness()))
+                ->setFloat("value", $block->getBreakInfo()->getHardness()))//Says seconds_to_destroy in docs
             ->setTag("minecraft:destructible_by_explosion", CompoundTag::create()
-                ->setFloat("value", $block->getBreakInfo()->getBlastResistance()))
+                ->setFloat("value", $block->getBreakInfo()->getBlastResistance()))//Uses explosion_resistance in docs
             ->setTag("minecraft:friction", CompoundTag::create()
                 ->setFloat("value", $block->getFrictionFactor()))
             ->setTag("minecraft:flammable", CompoundTag::create()
-                ->setInt("catch_chance_modifier", $block->getFlameEncouragement())//Did MC revert this change or?
+                ->setInt("catch_chance_modifier", $block->getFlameEncouragement())
                 ->setInt("destroy_chance_modifier", $block->getFlammability()));
 
 		if($model !== null) {

--- a/src/world/LegacyBlockIdToStringIdMap.php
+++ b/src/world/LegacyBlockIdToStringIdMap.php
@@ -3,7 +3,7 @@
 namespace customiesdevs\customies\world;
 
 use pocketmine\utils\SingletonTrait;
-use const pocketmine\BEDROCK_DATA_PATH;
+use const pocketmine\PATH;
 
 final class LegacyBlockIdToStringIdMap {
 	use SingletonTrait;
@@ -21,7 +21,7 @@ final class LegacyBlockIdToStringIdMap {
 
 	public function __construct() {
 		/** @phpstan-var array<string, int> $blockIdMap */
-		$blockIdMap = json_decode((string)file_get_contents(BEDROCK_DATA_PATH . "block_id_map.json"), true);
+		$blockIdMap = json_decode((string)file_get_contents(PATH . "vendor/pocketmine/bedrock-block-upgrade-schema/block_legacy_id_map.json"), true);
 		$this->stringToLegacy = $blockIdMap;
 		/** @phpstan-var array<int, string> $flipped */
 		$flipped = array_flip($this->stringToLegacy);


### PR DESCRIPTION
This updates the pm4 version of customies to support the latest release of PMMP (1.16.0) which uses a different block_id_map location. 