### PR TITLE
update Feature/pm5 for pocketmine version 5.0.0 BETA 4

### DIFF
--- a/src/block/BlockPalette.php
+++ b/src/block/BlockPalette.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace customiesdevs\customies\block;
 
-use pocketmine\data\bedrock\block\BlockStateData;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\network\mcpe\convert\BlockStateDictionary;
 use pocketmine\network\mcpe\convert\BlockStateDictionaryEntry;
@@ -77,7 +76,6 @@ final class BlockPalette {
 		// using the name of the block, and keeping the order of the existing states.
 		$states = [];
 		foreach($this->getStates() as $state){
-
 			$states[$state->getStateName()][] = $state;
 		}
 		// Append the new state we are sorting with at the end to preserve existing order.
@@ -96,8 +94,8 @@ final class BlockPalette {
 		$this->states = $sortedStates;
 		$this->bedrockKnownStates->setValue($this->dictionary, $sortedStates);
 		$this->lookupCache->setValue(
-            $this->dictionary,
-            new BlockStateDictionary(array_map(fn(BlockStateDictionaryEntry $entry) => $entry->getRawStateProperties(), $this->states))
+                    $this->dictionary,
+                    new BlockStateDictionary(array_map(fn(BlockStateDictionaryEntry $entry) => $entry->getRawStateProperties(), $this->states))
         );
 	}
 }

--- a/src/item/CustomiesItemFactory.php
+++ b/src/item/CustomiesItemFactory.php
@@ -11,7 +11,7 @@ use pocketmine\item\Item;
 use pocketmine\item\ItemIdentifier;
 use pocketmine\item\ItemTypeIds;
 use pocketmine\item\StringToItemParser;
-use pocketmine\network\mcpe\convert\GlobalItemTypeDictionary;
+use pocketmine\network\mcpe\convert\TypeConverter;
 use pocketmine\network\mcpe\protocol\types\CacheableNbt;
 use pocketmine\network\mcpe\protocol\types\ItemComponentPacketEntry;
 use pocketmine\network\mcpe\protocol\types\ItemTypeEntry;
@@ -96,7 +96,7 @@ final class CustomiesItemFactory {
 	 * Registers a custom item ID to the required mappings in the global ItemTypeDictionary instance.
 	 */
 	private function registerCustomItemMapping(string $identifier, int $itemId): void {
-		$dictionary = GlobalItemTypeDictionary::getInstance()->getDictionary();
+		$dictionary = TypeConverter::getInstance()->getItemTypeDictionary();
 		$reflection = new ReflectionClass($dictionary);
 
 		$intToString = $reflection->getProperty("intToStringIdMap");

--- a/src/task/AsyncRegisterBlocksTask.php
+++ b/src/task/AsyncRegisterBlocksTask.php
@@ -6,22 +6,22 @@ namespace customiesdevs\customies\task;
 use customiesdevs\customies\block\CustomiesBlockFactory;
 use pocketmine\block\Block;
 use pocketmine\scheduler\AsyncTask;
-use ThreadedArray;
+use pmmp\thread\ThreadSafeArray;
 
 final class AsyncRegisterBlocksTask extends AsyncTask {
 
-	private ThreadedArray $blockFuncs;
-	private ThreadedArray $objectToState;
-	private ThreadedArray $stateToObject;
+	private ThreadSafeArray $blockFuncs;
+	private ThreadSafeArray $objectToState;
+	private ThreadSafeArray $stateToObject;
 
 	/**
 	 * @param Closure[] $blockFuncs
 	 * @phpstan-param array<string, Closure(int): Block> $blockFuncs
 	 */
 	public function __construct(array $blockFuncs) {
-		$this->blockFuncs = new ThreadedArray();
-		$this->objectToState = new ThreadedArray();
-		$this->stateToObject = new ThreadedArray();
+		$this->blockFuncs = new ThreadSafeArray();
+		$this->objectToState = new ThreadSafeArray();
+		$this->stateToObject = new ThreadSafeArray();
 
 		foreach($blockFuncs as $identifier => [$blockFunc, $objectToState, $stateToObject]){
 			$this->blockFuncs[$identifier] = $blockFunc;


### PR DESCRIPTION
Juste Error on **BlockPalette** : 
` TypeError: "Cannot assign pocketmine\network\mcpe\convert\BlockStateDictionary to property pocketmine\network\mcpe\convert\BlockStateDictionary::$idMetaToStateIdLookupCache of type ?array" (EXCEPTION) in "plugins/Customies/src/block/BlockPalette" at line 100
`
