### PR TITLE
Compatibility fix for 1.20.10 blocks

### DIFF
--- a/src/block/Model.php
+++ b/src/block/Model.php
@@ -45,7 +45,7 @@ final class Model {
 			$material["minecraft:unit_cube"] = CompoundTag::create();
 		} else {
 			$material["minecraft:geometry"] = CompoundTag::create()
-				->setString("value", $this->geometry);
+				->setString("identifier", $this->geometry);
 			$material["minecraft:collision_box"] = CompoundTag::create()
 				->setByte("enabled", 1)
 				->setTag("origin", new ListTag([


### PR DESCRIPTION
In 1.20.10, minecraft changed the geometry tag to an object, replacing `value` with `identifier`.
This is the reason blocks with custom geometry were invisible.