### PR TITLE
Change Permutable::getCurrentBlockProperties() return value to mixed[]

### DIFF
--- a/src/block/permutations/Permutable.php
+++ b/src/block/permutations/Permutable.php
@@ -25,7 +25,7 @@ interface Permutable {
 	/**
 	 * Returns an array of the current block property values in the same order as those in getBlockProperties(). It is
 	 * used to convert the current properties in to a meta value that can be stored on disk in the world.
-	 * @return BlockProperty[]
+	 * @return mixed[]
 	 */
 	public function getCurrentBlockProperties(): array;
 


### PR DESCRIPTION
Doc comment should be a mixed array intead of a BlockProperty array because it returns BlockProperty **values**