### PR TITLE
Don't send unnecessary block components

### DIFF
--- a/src/block/CustomiesBlockFactory.php
+++ b/src/block/CustomiesBlockFactory.php
@@ -97,13 +97,8 @@ final class CustomiesBlockFactory {
 				->setByte("lightLevel", $block->getLightFilter()))
 			->setTag("minecraft:destructible_by_mining", CompoundTag::create()
 				->setFloat("value", $block->getBreakInfo()->getHardness()))
-			->setTag("minecraft:destructible_by_explosion", CompoundTag::create()
-				->setFloat("value", $block->getBreakInfo()->getBlastResistance()))
 			->setTag("minecraft:friction", CompoundTag::create()
-				->setFloat("value", $block->getFrictionFactor()))
-			->setTag("minecraft:flammable", CompoundTag::create()
-				->setInt("catch_chance_modifier", $block->getFlameEncouragement())
-				->setInt("destroy_chance_modifier", $block->getFlammability()));
+				->setFloat("value", $block->getFrictionFactor()));
 
 		if($model !== null) {
 			foreach($model->toNBT() as $tagName => $tag){


### PR DESCRIPTION
These components are totally useless for the client, because these components are only useful for server-side logic.

It was also tested that these components are not sent by BDS to the client through a MITM proxy.