### PR TITLE
Rename `minecraft:block_light_filter` component to `minecraft:light_dampening`

### DIFF
--- a/src/block/CustomiesBlockFactory.php
+++ b/src/block/CustomiesBlockFactory.php
@@ -93,7 +93,7 @@ final class CustomiesBlockFactory {
 		$components = CompoundTag::create()
 			->setTag("minecraft:light_emission", CompoundTag::create()
 				->setByte("emission", $block->getLightLevel()))
-			->setTag("minecraft:block_light_filter", CompoundTag::create()
+			->setTag("minecraft:light_dampening", CompoundTag::create()
 				->setByte("lightLevel", $block->getLightFilter()))
 			->setTag("minecraft:destructible_by_mining", CompoundTag::create()
 				->setFloat("value", $block->getBreakInfo()->getHardness()))


### PR DESCRIPTION
This component was renamed to `minecraft:light_dampening` on [1.19.10](https://www.minecraft.net/en-us/article/1-19-10-update-out-bedrock)

It can also be seen that this component was renamed through a MITM proxy by dumping StartGamePacket.