### PR TITLE
Remove unused code

### DIFF
--- a/src/Customies.php
+++ b/src/Customies.php
@@ -12,11 +12,10 @@ final class Customies extends PluginBase {
 	protected function onEnable(): void {
 		$this->getServer()->getPluginManager()->registerEvents(new CustomiesListener(), $this);
 
-		$cachePath = $this->getDataFolder() . "idcache";
-		$this->getScheduler()->scheduleDelayedTask(new ClosureTask(static function () use ($cachePath): void {
+		$this->getScheduler()->scheduleDelayedTask(new ClosureTask(static function (): void {
 			// This task is scheduled with a 0-tick delay so it runs as soon as the server has started. Plugins should
 			// register their custom blocks and entities in onEnable() before this is executed.
-			CustomiesBlockFactory::getInstance()->addWorkerInitHook($cachePath);
+			CustomiesBlockFactory::getInstance()->addWorkerInitHook();
 		}), 0);
 	}
 }

--- a/src/block/CustomiesBlockFactory.php
+++ b/src/block/CustomiesBlockFactory.php
@@ -29,6 +29,7 @@ use pocketmine\utils\SingletonTrait;
 use pocketmine\world\format\io\GlobalBlockStateHandlers;
 use function array_map;
 use function array_reverse;
+use function assert;
 use function hash;
 use function strcmp;
 use function usort;
@@ -51,11 +52,11 @@ final class CustomiesBlockFactory {
 	 * It is especially important for the workers that deal with chunk encoding, as using the wrong runtime ID mappings
 	 * can result in massive issues with almost every block showing as the wrong thing and causing lag to clients.
 	 */
-	public function addWorkerInitHook(string $cachePath): void {
+	public function addWorkerInitHook(): void {
 		$server = Server::getInstance();
 		$blocks = $this->blockFuncs;
-		$server->getAsyncPool()->addWorkerStartHook(static function (int $worker) use ($cachePath, $server, $blocks): void {
-			$server->getAsyncPool()->submitTaskToWorker(new AsyncRegisterBlocksTask($cachePath, $blocks), $worker);
+		$server->getAsyncPool()->addWorkerStartHook(static function (int $worker) use ($server, $blocks): void {
+			$server->getAsyncPool()->submitTaskToWorker(new AsyncRegisterBlocksTask($blocks), $worker);
 		});
 	}
 

--- a/src/block/permutations/Permutable.php
+++ b/src/block/permutations/Permutable.php
@@ -23,13 +23,6 @@ interface Permutable {
 	public function getPermutations(): array;
 
 	/**
-	 * Returns an array of the current block property values in the same order as those in getBlockProperties(). It is
-	 * used to convert the current properties in to a meta value that can be stored on disk in the world.
-	 * @return mixed[]
-	 */
-	public function getCurrentBlockProperties(): array;
-
-	/**
 	 * Serializes the block state to the given BlockStateWriter.
 	 */
 	public function serializeState(BlockStateWriter $blockStateOut): void;

--- a/src/block/permutations/Permutations.php
+++ b/src/block/permutations/Permutations.php
@@ -3,53 +3,14 @@ declare(strict_types=1);
 
 namespace customiesdevs\customies\block\permutations;
 
-use Exception;
 use function array_map;
+use function array_product;
 use function count;
 use function current;
 use function next;
 use function reset;
 
 class Permutations {
-
-	/**
-	 * Attempts to return an array of block properties from the provided meta value based on the possible permutations
-	 * of the block. An exception is thrown if the meta value does not match any combinations of all the block
-	 * properties.
-	 */
-	public static function fromMeta(Permutable $block, int $meta): array {
-		$properties = self::getCartesianProduct(
-			array_map(static fn(BlockProperty $blockProperty) => $blockProperty->getValues(), $block->getBlockProperties())
-		)[$meta] ?? null;
-		if($properties === null) {
-			throw new Exception("Unable to calculate permutations from block meta: " . $meta);
-		}
-		return $properties;
-	}
-
-	/**
-	 * Attempts to convert the block in to a meta value based on the possible permutations of the block. An exception is
-	 * thrown if the state of the block is not a possible combination of all the block properties.
-	 */
-	public static function toMeta(Permutable $block): int {
-		$properties = self::getCartesianProduct(
-			array_map(static fn(BlockProperty $blockProperty) => $blockProperty->getValues(), $block->getBlockProperties())
-		);
-		foreach($properties as $meta => $permutations){
-			if($permutations === $block->getCurrentBlockProperties()) {
-				return $meta;
-			}
-		}
-		throw new Exception("Unable to calculate block meta from current permutations");
-	}
-
-	/**
-	 * Returns the number of bits required to represent all the possible permutations of the block.
-	 */
-	public static function getStateBitmask(Permutable $block): int {
-		$possibleValues = array_map(static fn(BlockProperty $blockProperty) => $blockProperty->getValues(), $block->getBlockProperties());
-		return count(self::getCartesianProduct($possibleValues)) - 1;
-	}
 
 	/**
 	 * Returns an 2-dimensional array containing all possible combinations of the provided arrays using the cartesian

--- a/src/block/permutations/RotatableTrait.php
+++ b/src/block/permutations/RotatableTrait.php
@@ -8,7 +8,6 @@ use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\data\bedrock\block\convert\BlockStateReader;
 use pocketmine\data\bedrock\block\convert\BlockStateWriter;
 use pocketmine\item\Item;
-use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\player\Player;
@@ -76,23 +75,6 @@ trait RotatableTrait {
 					->setFloat("TY", 0.0)
 					->setFloat("TZ", 0.0)),
 		];
-	}
-
-	public function getCurrentBlockProperties(): array {
-		return [$this->facing];
-	}
-
-	protected function writeStateToMeta(): int {
-		return Permutations::toMeta($this);
-	}
-
-	public function readStateFromData(int $id, int $stateMeta): void {
-		$blockProperties = Permutations::fromMeta($this, $stateMeta);
-		$this->facing = $blockProperties[0] ?? Facing::NORTH;
-	}
-
-	public function getStateBitmask(): int {
-		return Permutations::getStateBitmask($this);
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null): bool {

--- a/src/item/CustomiesItemFactory.php
+++ b/src/item/CustomiesItemFactory.php
@@ -90,7 +90,7 @@ final class CustomiesItemFactory {
 		$reflection = new ReflectionClass($dictionary);
 
 		$intToString = $reflection->getProperty("intToStringIdMap");
-		/** @var int[] $value */
+		/** @var string[] $value */
 		$value = $intToString->getValue($dictionary);
 		$intToString->setValue($dictionary, $value + [$itemId => $identifier]);
 

--- a/src/item/component/RarityComponent.php
+++ b/src/item/component/RarityComponent.php
@@ -15,7 +15,7 @@ final class RarityComponent implements ItemComponent {
 	/**
 	 * Rarity Component enables the specifying of the base rarity of an item. 
 	 * The rarity of the item will determine which color it uses for its name, unless the item has a HoverTextColor component specified, in which case that hover text color will take priority and be used instead of the rarity color.
-	 * @param string $type Sets the base rarity of the item. The rarity of an item automatically increases when enchanted, either to Rare when the base rarity is Common or Uncommon, or Epic when the base rarity is Rare
+	 * @param string $rarity Sets the base rarity of the item. The rarity of an item automatically increases when enchanted, either to Rare when the base rarity is Common or Uncommon, or Epic when the base rarity is Rare
 	 */
 	public function __construct(string $rarity = self::COMMON) {
 		$this->rarity = $rarity;

--- a/src/task/AsyncRegisterBlocksTask.php
+++ b/src/task/AsyncRegisterBlocksTask.php
@@ -20,7 +20,7 @@ final class AsyncRegisterBlocksTask extends AsyncTask {
 	 * @param Closure[] $blockFuncs
 	 * @phpstan-param array<string, array{(Closure(int): Block), (Closure(BlockStateWriter): Block), (Closure(Block): BlockStateReader)}> $blockFuncs
 	 */
-	public function __construct(private string $cachePath, array $blockFuncs) {
+	public function __construct(array $blockFuncs) {
 		$this->blockFuncs = new ThreadSafeArray();
 		$this->serializer = new ThreadSafeArray();
 		$this->deserializer = new ThreadSafeArray();


### PR DESCRIPTION
Remove unused code from pm4 to pm5 transition

## Changed API related code

- Removed `getCurrentBlockProperties()` function from `Permutable` interface
- Removed `fromMeta()` function from `Permutations` class
- Removed `toMeta()` function from `Permutations` class
- Removed `getStateBitmask()` function from `Permutations` class