### PR TITLE
Fix GlintComponent name and reorder RecordComponent constructor

### DIFF
--- a/src/item/component/GlintComponent.php
+++ b/src/item/component/GlintComponent.php
@@ -16,7 +16,7 @@ final class GlintComponent implements ItemComponent {
 	}
 
 	public function getName(): string {
-		return "foil";
+		return "minecraft:glint";
 	}
 
 	public function getValue(): bool {

--- a/src/item/component/RecordComponent.php
+++ b/src/item/component/RecordComponent.php
@@ -15,7 +15,7 @@ final class RecordComponent implements ItemComponent {
 	 * @param float $duration Specifies duration of sound event in seconds, float value
 	 * @param string $soundEvent Sound event type: 13, cat, blocks, chirp, far, mall, mellohi, stal, strad, ward, 11, wait, pigstep, otherside, 5, relic
 	 */
-	public function __construct(int $comparatorSignal = 1, float $duration, string $soundEvent = "undefined") {
+	public function __construct(float $duration, int $comparatorSignal = 1, string $soundEvent = "undefined") {
 		$this->comparatorSignal = $comparatorSignal;
 		$this->duration = $duration;
 		$this->soundEvent = $soundEvent;


### PR DESCRIPTION
glint wasn’t showing, record was causing some gray error in console (param order mismatch i think)

changed glint getName to "minecraft:glint"  
switched record constructor param order (duration first)

thanks 👍