### PR TITLE
identifier is always lower!!

### DIFF
--- a/src/item/CustomiesItemFactory.php
+++ b/src/item/CustomiesItemFactory.php
@@ -63,14 +63,14 @@ final class CustomiesItemFactory {
 		$itemId = ItemTypeIds::newId();
 		$item = new $className(new ItemIdentifier($itemId), $name);
 
-		GlobalItemDataHandlers::getDeserializer()->map($identifier, fn() => clone $item);
-		GlobalItemDataHandlers::getSerializer()->map($item, fn() => new SavedItemData($identifier));
+		GlobalItemDataHandlers::getDeserializer()->map(strtolower($identifier), fn() => clone $item);
+		GlobalItemDataHandlers::getSerializer()->map($item, fn() => new SavedItemData(strtolower($identifier)));
 
-		StringToItemParser::getInstance()->register($identifier, fn() => clone $item);
+		StringToItemParser::getInstance()->register(strtolower($identifier), fn() => clone $item);
 
 		$nbt = ($componentBased = $item instanceof ItemComponents) ? $item->getComponents()
 			->setInt("id", $itemId)
-			->setString("name", $identifier) : CompoundTag::create();
+			->setString("name", strtolower($identifier)) : CompoundTag::create();
 
 		$this->itemTableEntries[$identifier] = $entry = new ItemTypeEntry($identifier, $itemId, $componentBased, $componentBased ? 1 : 0, new CacheableNbt($nbt));
 		$this->registerCustomItemMapping($identifier, $itemId, $entry);


### PR DESCRIPTION
**Summary:**
This patch fixes a texture loading issue caused by uppercase letters in custom item/block identifiers.
Details:
- Converts $identifier to lowercase during registration.
- Ensures consistent identifier formatting without modifying texture filenames or resource pack contents.
- Prevents case-sensitive mismatches between game engine and resource definitions.
**Impact:**
Improves reliability of texture loading for custom items/blocks by enforcing lowercase identifiers. No changes to texture files or resource pack structure required.
